### PR TITLE
reducing logo size in jumbotron

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -104,7 +104,7 @@ nav
 
 .jumbotron img
   @extend .img-fluid
-  max-width: 90%
+  max-width: 68%
   height: auto
 
 .jumbotron


### PR DESCRIPTION
As per [feedback session](https://docs.google.com/document/d/1SIcIzndh6DYs3cZRA8f8_CSbgzCYQxO-0lNrI7fEjhY/edit#heading=h.srmpijc6p10e), reducing logo size in jumbotron.

Does this size work better for you @dcbw?

Fixes #39 