### PR TITLE
Fixing a typo in Firewall README

### DIFF
--- a/content/plugins/meta/firewall.md
+++ b/content/plugins/meta/firewall.md
@@ -137,8 +137,8 @@ CNI-FORWARD will have a pair of rules added, one for each direction, using the I
 of the container as shown:
 
 `CNI-FORWARD` chain:
-- `-s 10.88.0.2 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT`
-- `-d 10.88.0.2 -j ACCEPT`
+- `-d 10.88.0.2 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT`
+- `-s 10.88.0.2 -j ACCEPT`
 
 The `CNI-FORWARD` chain first sends all traffic to `CNI-ADMIN` chain, which is intended as an user-controlled chain for custom rules that run prior to rules managed by the `firewall` plugin. The `firewall` plugin does not add, delete or modify rules in the `CNI-ADMIN` chain.
 


### PR DESCRIPTION
Correct me if I am wrong, I am pretty sure these flags are swapped in the README which caused a small confusion as I was reading it. We can refer to https://github.com/containernetworking/plugins/blob/master/plugins/meta/firewall/iptables.go#L31&#L32 to see what they really are set to.

I was originally going to open the fix in the plugins repo, but then I saw this PR https://github.com/containernetworking/plugins/pull/549 that is migrating everything to this repo.