### PR TITLE
v0.8.7_always_cache_into_cachedir

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,23 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
 enableGitInfo = true
 
+[caches]
+ [caches.assets]
+  dir = ":cacheDir/_gen"
+  maxAge = -1
+ [caches.getcsv]
+  dir = ":cacheDir/:project"
+  maxAge = "60s"
+ [caches.getjson]
+  dir = ":cacheDir/:project"
+  maxAge = "60s"
+ [caches.images]
+  dir = ":cacheDir/_images"
+  maxAge = -1
+ [caches.modules]
+  dir = ":cacheDir/modules"
+  maxAge = -1
+
 [markup.highlight]
 style = "paraiso-dark"
 


### PR DESCRIPTION
By default Hugo puts some cache information outside of its cacheDir. Set
Hugo to write all cached files inside the configured cache directory.