### PR TITLE
update host-device readme for dpdk support

### DIFF
--- a/content/plugins/main/host-device.md
+++ b/content/plugins/main/host-device.md
@@ -13,6 +13,8 @@ Move an already-existing device into a container.
 
 This simple plugin will move the requested device from the host's network namespace
 to the container's. IPAM configuration can be used for this plugin.
+This plugin can also be used for a device bound to dpdk driver via `pciBusID` or
+runtimeConfig `deviceID` parameter then IPAM configuration will be ignored.
 
 ## Network configuration reference
 


### PR DESCRIPTION
Update host-device readme for supporting dpdk device. 
Here is the dependent [PR](https://github.com/containernetworking/plugins/pull/490).

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>