### PR TITLE
Provide vlan plugin documentation

### DIFF
--- a/content/plugins/current/_index.md
+++ b/content/plugins/current/_index.md
@@ -19,6 +19,7 @@ These are general-purpose CNI network plugins maintained by the containernetwork
 * [`macvlan`](main/macvlan): Creates a new MAC address, forwards all traffic to that to the container
 * [`ptp`](main/ptp): Creates a veth pair
 * [`host-device`](main/host-device): Moves an already-existing device into a container
+* [`vlan`](main/vlan): Creates a vlan interface off a master
 
 #### Windows: windows specific
 

--- a/content/plugins/current/main/_index.md
+++ b/content/plugins/current/main/_index.md
@@ -12,6 +12,7 @@ weight: 100
 * [`macvlan`](macvlan): Creates a new MAC address, forwards all traffic to that to the container
 * [`ptp`](ptp): Creates a veth pair
 * [`host-device`](host-device): Moves an already-existing device into a container
+* [`vlan`](vlan): Creates a vlan interface off a master
 
 ### Windows: windows specific
 * [`win-bridge`](win-bridge): Creates a bridge, adds the host and the container to it

--- a/content/plugins/current/main/vlan.md
+++ b/content/plugins/current/main/vlan.md
@@ -1,0 +1,41 @@
+---
+title: vlan plugin
+description: "plugins/main/vlan/README.md"
+date: 2021-10-17
+toc: true
+draft: false
+weight: 200
+---
+
+## Overview
+The vlan plugin creates a vlan subinterface off an enslaved interface in the host network namespace and the container using a veth device. One end of the veth pair is placed inside a container and the other end is a subinterface off the master in the host network namespace. The host-local IPAM plugin can be used to allocate an IP address to the container. The traffic of the container interface will be routed through the interface of the host.
+
+## Example network configuration
+
+```json
+{
+	"name": "mynet",
+	"cniVersion": "1.0.0",
+	"type": "vlan",
+	"master": "eth0",
+	"mtu": 1500,
+	"vlanId": 5,
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.1.1.0/24"
+	},
+	"dns": {
+		"nameservers": [ "10.1.1.1", "8.8.8.8" ]
+	}
+}
+```
+
+## Network configuration reference
+
+* `name` (string, required): the name of the network
+* `type` (string, required): "vlan"
+* `master` (string, required): name of the host interface to enslave. Defaults to default route interface.
+* `vlanId` (integer, required): id of the vlan
+* `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to value chosen by the kernel.
+* `ipam` (dictionary, required): IPAM configuration to be used for this network.
+* `dns` (dictionary, optional): DNS information to return as described in the [Result](https://github.com/containernetworking/cni/blob/master/SPEC.md#result).

--- a/content/plugins/current/main/vlan.md
+++ b/content/plugins/current/main/vlan.md
@@ -15,7 +15,7 @@ The vlan plugin creates a vlan subinterface off an enslaved interface in the hos
 ```json
 {
 	"name": "mynet",
-	"cniVersion": "1.0.0",
+	"cniVersion": "0.3.1",
 	"type": "vlan",
 	"master": "eth0",
 	"mtu": 1500,


### PR DESCRIPTION
I noticed for a while that the vlan plugin documentation was missing. I wanted to get the ball rolling on it. I wasn't sure if I should put this in current and 1.0.0 or the other directory? If the maintainers have a preference I can update the PR. 