### PR TITLE
Remove vlanTrunk example with vlanID

### DIFF
--- a/content/plugins/current/main/bridge.md
+++ b/content/plugins/current/main/bridge.md
@@ -54,7 +54,6 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
     "name": "mynet",
     "type": "bridge",
     "bridge": "mynet0",
-    "vlan": 100,
     "vlanTrunk": [
         { "id": 101 },
         { "minID": 200, "maxID": 299 }


### PR DESCRIPTION
Current vlanTrunk and vlan are excluded.

refer: https://github.com/containernetworking/plugins/pull/829