### PR TITLE
bridge: Fix example json formatting

### DIFF
--- a/content/plugins/current/main/bridge.md
+++ b/content/plugins/current/main/bridge.md
@@ -70,7 +70,7 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
     "name": "mynet",
     "type": "bridge",
     "bridge": "mynet0",
-    "disableContainerInterface": "true",
+    "disableContainerInterface": true
 }
 ```
 


### PR DESCRIPTION
Tiny fix for the recently added bridge example's json formatting.